### PR TITLE
fix selectedIndex issue on Controlled Mode

### DIFF
--- a/addon/components/aria-tabs.js
+++ b/addon/components/aria-tabs.js
@@ -232,6 +232,7 @@ For more information about controlled and uncontrolled mode of ember-aria-tabs s
         // Check if the change event handler cancels the tab change
         return;
       }
+      this.selectedIndex = this.args.selectedIndex
     }
 
     this.focus = event.type === 'keydown';


### PR DESCRIPTION
Fixes https://github.com/concordnow/ember-aria-tabs/issues/244

Currently updating this.args.selectedIndex doesn't propagate to the DOM because  `@tracked this.selectedIndex` never ends up getting updated.

This PR fixes that issue by overwriting existing `this.selectedIndex` with the new provided `this.args.selectedIndex`