### PR TITLE
Add missing default class name for tab list

### DIFF
--- a/addon/components/aria-tab-list.hbs
+++ b/addon/components/aria-tab-list.hbs
@@ -1,4 +1,4 @@
-<ul role="tablist" ...attributes>
+<ul class={{this.className}} role="tablist" ...attributes>
   {{yield
     (hash
       tab=(component

--- a/tests/integration/components/aria-tab-list-test.js
+++ b/tests/integration/components/aria-tab-list-test.js
@@ -16,11 +16,19 @@ module('Integration | Component | aria-tab-list', function (hooks) {
     assert.equal(tabList.textContent.trim(), '');
   });
 
+  test('it renders with the default class', async function (assert) {
+    await render(hbs`<AriaTabList />`);
+
+    let tabList = this.element.querySelector('[role="tablist"]');
+    assert.equal(tabList.classList.contains('ember-tabs__tab-list'), true);
+  });
+
   test('it renders with class', async function (assert) {
     await render(hbs`<AriaTabList class="foobar" />`);
 
     let tabList = this.element.querySelector('[role="tablist"]');
     assert.equal(tabList.classList.contains('foobar'), true);
+    assert.equal(tabList.classList.contains('ember-tabs__tab-list'), true);
   });
 
   test('it pass through custom properties', async function (assert) {


### PR DESCRIPTION
Add missing default class name `ember-tabs__tab-list` to tab list, as specified in the [documentation](https://concordnow.github.io/ember-aria-tabs/#/docs/components/aria-tab-list) for the component.