### PR TITLE
Fix broken tab switching in controlled mode

### DIFF
--- a/addon/components/aria-tabs.hbs
+++ b/addon/components/aria-tabs.hbs
@@ -1,8 +1,8 @@
 <div
   class={{this.className}}
   ...attributes
-  {{did-insert this.didUpsert this.tabIds this.panelIds}}
-  {{did-update this.didUpsert this.tabIds this.panelIds}}
+  {{did-insert this.didUpsert this.tabIds this.panelIds @selectedIndex}}
+  {{did-update this.didUpsert this.tabIds this.panelIds @selectedIndex}}
 >
   {{yield
     (hash

--- a/tests/integration/components/aria-tabs-test.js
+++ b/tests/integration/components/aria-tabs-test.js
@@ -243,6 +243,38 @@ module('Integration | Component | aria-tabs', function (hooks) {
     assert.equal(panels[3].textContent.trim(), 'Hello Qux false');
   });
 
+  test('it changes the selected tab in controlled mode', async function (assert) {
+    this.tabIndex = 0;
+
+    await render(hbs`
+      <AriaTabs @selectedIndex={{this.tabIndex}} @onSelect={{fn (mut this.tabIndex)}} as |at|>
+        <at.tabList as |tl|>
+          <tl.tab as |t|>Foo {{t.selected}}</tl.tab>
+          <tl.tab as |t|>Bar {{t.selected}}</tl.tab>
+        </at.tabList>
+        <at.tabPanel as |tp|>Hello Foo {{tp.selected}}</at.tabPanel>
+        <at.tabPanel as |tp|>Hello Bar {{tp.selected}}</at.tabPanel>
+      </AriaTabs>
+    `);
+
+    let tabs = findAll('[role="tab"]');
+    let panels = findAll('[role="tabpanel"]');
+
+    assertTabSelected(assert, 0);
+
+    assert.equal(tabs[0].textContent.trim(), 'Foo true');
+    assert.equal(tabs[1].textContent.trim(), 'Bar false');
+
+    assert.equal(panels[0].textContent.trim(), 'Hello Foo true');
+    assert.equal(panels[1].textContent.trim(), '');
+
+    await click(tabs[1]);
+    assertTabSelected(assert, 1);
+
+    assert.equal(panels[0].textContent.trim(), '');
+    assert.equal(panels[1].textContent.trim(), 'Hello Bar true');
+  });
+
   test('it does not change selectedIndex when clicking a disabled tab', async function (assert) {
     await createTabs();
 


### PR DESCRIPTION
Fixes https://github.com/concordnow/ember-aria-tabs/issues/244

Fix tab switching in controlled mode, which is currently failing due to the `@selectedIndex` changing without triggering a change of `this.selectedIndex`. Also adds a corresponding test to prevent future regressions.

This is an alternate solution to https://github.com/concordnow/ember-aria-tabs/pull/245.