### PR TITLE
Bump node ci with overrides

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 3 * * *' # daily, at 3am
 
 env:
-  NODE_VERSION: '12'
+  NODE_VERSION: '16'
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
     "configPath": "tests/dummy/config"
   },
   "volta": {
-    "node": "12.22.7",
-    "npm": "7.24.2"
+    "node": "16.15.0"
+  },
+  "overrides": {
+    "ember-source": "$ember-source"
   }
 }


### PR DESCRIPTION
This extends https://github.com/concordnow/ember-aria-tabs/pull/424 by
 - updating the Volta config to match the GitHub actions config
 - using NPM overrides for ember-source so that NPM 8 does not complain about addons receiving prerelease versions of ember-source.