### PR TITLE
chore(deps): pin qs to ^6.15.2 (GHSA-q8mj-m7cp-5q26)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5042,22 +5042,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/body/node_modules/bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
@@ -20025,9 +20009,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "braces": "^3.0.3",
     "micromatch": "^4.0.8",
     "markdown-it": "^14.1.1",
-    "clean-css": "^5.3.3"
+    "clean-css": "^5.3.3",
+    "qs": "^6.15.2"
   }
 }


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` entry pinning `qs` to `^6.15.2`, remediating Dependabot alert [#174](https://github.com/concordnow/ember-aria-tabs/security/dependabot/174) (`GHSA-q8mj-m7cp-5q26`, DoS in `qs.stringify`).
- `qs` is a dev-only transitive dep (pulled in via the `ember-cli` / `testem` dev-server stack: `express`, `body-parser`, `tiny-lr`) — not shipped to addon consumers.
- Follows the same `overrides` pattern introduced in fac24e4 (CVE remediation 31→0), so this change avoids bumping `ember-cli` and stays compatible with Ember 3.28.
- After `npm install`, the two nested `qs` copies (`6.14.2` and `6.15.1`) deduplicate to a single `qs@6.15.2`. `@types/qs` is unaffected (types only, not covered by the advisory).

## Test plan
- [x] `npm install` — lockfile resolves cleanly, `qs` collapses to `6.15.2`
- [x] `npm run lint` — clean
- [x] `npm run test:ember` — 47/47 pass on Chrome 148
- [x] `npm audit` — `qs` advisory no longer reported
- [ ] CI: `test`, `floating-dependencies`, and the 8 `try-scenarios` jobs (incl. lts-3.20, lts-3.24, lts-5.4, lts-5.12, lts-6.12)