### PR TITLE
chore(deps): bump tmp override to ^0.2.6 to remediate GHSA-ph9p-34f9-6g65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-aria-tabs",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-aria-tabs",
-      "version": "7.1.3",
+      "version": "7.1.4",
       "license": "MIT",
       "dependencies": {
         "@ember/render-modifiers": "^2.0.0",
@@ -24163,9 +24163,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "undici": "^7.24.5",
     "@babel/runtime": "^7.26.10",
     "@babel/helpers": "^7.26.10",
-    "tmp": "^0.2.5",
+    "tmp": "^0.2.6",
     "got": "^11.8.6",
     "diff": "^8.0.3",
     "ansi-html": "npm:ansi-html-community@^0.0.8",


### PR DESCRIPTION
## Résumé

Remédiation de l'alerte Dependabot #175 — **GHSA-ph9p-34f9-6g65 / CVE-2026-44705** : path traversal dans `tmp` via `prefix`/`postfix`/`dir` non sanitisés (CWE-22, High, CVSS 4.0 = 7.7).

- Plage vulnérable : `tmp < 0.2.6`
- Avant : `tmp@0.2.5` (transitif, dev/build-time uniquement — toolchain `ember-cli`, `ember-template-lint`, etc.)
- Après : `tmp@0.2.7` via relèvement du plancher de l'override existant `^0.2.5` → `^0.2.6`

## Impact

**Aucun impact consommateur** : `tmp` n'est pas utilisé par le code source de l'addon publié (output transpilé). Même profil que les remédiations précédentes (`qs` en 7.1.3). Pas de bump de version ni d'entrée changelog dans cette PR.

## Vérifications

- ✅ `npm ls tmp` → `0.2.7` partout (overridden), aucune occurrence de `0.2.5` dans le lockfile
- ✅ `npm run lint` passe (toolchain consommant `tmp` fonctionnelle)

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)