### PR TITLE
fix(deps): bump shell-quote 1.8.3 → 1.8.4 (GHSA-w7jw-789q-3m8p, critical)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22067,9 +22067,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Contexte
L'advisory **GHSA-w7jw-789q-3m8p** (severity: **critical**) a été publiée le 2026-06-09 : `shell-quote` ≤ 1.8.3, `quote()` n'échappe pas les retours à la ligne dans les valeurs `.op` des objets (injection de commande possible).

## Changement
Bump de `shell-quote` **1.8.3 → 1.8.4** (première version corrigée). **devDependency transitive** ; seul `package-lock.json` est impacté.

## Vérification
```
npm audit (avant) : 1 critical (shell-quote)
npm audit (après) : found 0 vulnerabilities
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)