### PR TITLE
ci: allow ember-release to fail to unblock dependabot auto-merge

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -64,6 +64,19 @@ module.exports = async function () {
       },
       {
         name: 'ember-release',
+        // Allowed to fail: since Ember 7.0 (2026-05-12) the release channel
+        // ships a pure v2 addon with no legacy AMD/vendor bundles and no
+        // `paths` export. ember-cli 4.12's `_initVendorFiles` reads
+        // `ember.paths.debug` unconditionally, so the build crashes with
+        // `TypeError: Cannot read properties of undefined (reading 'debug')`
+        // before any test runs. Same root cause as ember-lts-6.12 above, one
+        // major further along: there the AMD bundle is merely deprecated,
+        // here it is gone.
+        // This scenario was green until 54eb066 dropped the flag, which was
+        // validated against release=6.12 days before 7.0 shipped.
+        // TODO(@YoanRoullard): drop once ember-cli is bumped to a version
+        // that loads Ember via ES modules (planned in a follow-up PR).
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),


### PR DESCRIPTION
## Why

`Try: ember-release` has been red on **every** CI run since 2026-05-20. Root cause: Ember 7.0.0 (published 2026-05-12) became a pure v2 addon — it dropped the legacy AMD/vendor bundles and the `paths` export from `lib/index.js`. This repo pins `ember-cli ~4.12.3`, whose `_initVendorFiles` reads `ember.paths.debug` unconditionally, so the build crashes before a single test runs:

```
TypeError: Cannot read properties of undefined (reading 'debug')
    at EmberAddon._initVendorFiles (node_modules/ember-cli/lib/broccoli/ember-app.js:477:38)
```

The scenario was green before that date only because it carried `allowedToFail: true`. 54eb066 removed the flag; it was validated locally against `release=6.12` a few days before 7.0 shipped, so this was an unlucky race rather than an oversight.

## Why it matters more than a red badge

The `waiter` job in the **Dependabot auto-merge** workflow gates on all required checks going green. Because `ember-release` never goes green, `waiter` is **cancelled on every Dependabot PR** and none of them ever auto-merges.

The concrete cost right now: seven open Dependabot PRs (#700–#706), all dev-only security bumps, have been sitting unmerged for up to two weeks — including #700, which closes a **critical** advisory (CVE-2026-54466 / GHSA-xv26-6w52-cph6 in `websocket-driver`). So the red check is silently blocking security remediation.

## What this PR does

Restores `allowedToFail: true` on the `ember-release` scenario, mirroring how `ember-lts-6.12` is already handled — same root cause, one major earlier (there the AMD bundle is merely deprecated; here it is gone). The scenario keeps running and keeps reporting Ember 7 breakage in the logs; it just stops gating merges.

This is deliberately a **short-term unblock**, not the real fix. The real fix is the `ember-cli` bump promised in 54eb066 (refs #687), which is what will actually make Ember 7 build. The `TODO(@YoanRoullard)` comment points at it.

## Verification

Ran locally against the current release channel (`ember-source 7.1.0-release+7c6f1709`):

```
$ node_modules/.bin/ember try:one ember-release
...
Scenario ember-release: FAIL (Allowed)
1 scenarios failed (1 allowed)
0 scenarios succeeded
1 scenarios run
$ echo $?
0
```

The build still crashes — the flag does not hide the breakage from the log — but the command exits 0, so the GitHub job reports success and `waiter` is no longer starved.

`npm run lint` passes; `config/ember-try.js` parses and `ember-release` is the only scenario whose flags changed.

## Deliberately not in scope

54eb066 also added `ember-lts-5.4`, `ember-lts-5.12` and `ember-lts-6.12` to `config/ember-try.js` but never registered them in the workflow matrix, so that modern-Ember coverage has never run. Wiring them up belongs in a follow-up PR: `lts-5.4` and `lts-5.12` are not marked `allowedToFail` and have no CI history, so if either turns out red it would re-block the very gate this PR is fixing. Keeping them separate means an unverified scenario cannot hold up the security bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
